### PR TITLE
Speed up pandoc by running multiple instances in parallel.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Build PDFs
         run: |
           set -eou pipefail
+          export SHELLOPTS
           mkdir static
-          find public/docs/mhb_* -name "index.html" | while read fname; do
-            echo $(dirname $fname).pdf
-            xmllint --nowarning --html --xpath '/html/body/main/div/article' $fname 2> /dev/null | \
-              pandoc -f html -t pdf --template mhb_pandoc_template.latex -o \
-                static/$(basename $(dirname $fname)).pdf
-          done
+          find public/docs/mhb_* -type f -name "index.html" -print0 | \
+            xargs -0 -n1 -I {} -P4 \
+              sh -c "echo Converting \"{}\"...; xmllint --nowarning --html --xpath '/html/body/main/div/article' {} 2> /dev/null | \
+                pandoc -f html -t pdf --template mhb_pandoc_template.latex -o \
+                  static/\$(basename \$(dirname {})).pdf"
           mv static public/pdfs
           tar czf pageWithPdfs.tar.gz public
 


### PR DESCRIPTION
GitHub actions usually provides about virtual 2 cores, but I am using `4` here since a lot of time is likely spent in the I/O done by startup / stop of the processes. 

Likely, this can also be extended to concatenate the output of all `xmllint` calls and inject these into a single `pandoc` to merge all into one PDF. 